### PR TITLE
s3の権限足りてなかったのを修正

### DIFF
--- a/cfn/template/index.js
+++ b/cfn/template/index.js
@@ -78,7 +78,10 @@ module.exports = {
               "Action": [
                 "s3:*"
               ],
-              "Resource": `arn:aws:s3:::kao-class-${config.tags.Stage.toLowerCase()}`
+              "Resource": [
+                `arn:aws:s3:::kao-class-${config.tags.Stage.toLowerCase()}`,
+                `arn:aws:s3:::kao-class-${config.tags.Stage.toLowerCase()}/*`
+              ]
             }]
           }
         }],


### PR DESCRIPTION
http://dqn.sakusakutto.jp/2012/08/aws_iam_policy_s3_bucket.html

> ポイントは、"arn:aws:s3:::hogehoge"と"arn:aws:s3:::hogehoge/*"の両方を書くことです。

これ忘れていた・・・
